### PR TITLE
Show real app version in about window

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,6 +20,9 @@
       "beforeColon": false,
       "afterColon": true
     }],
+    "react/react-in-jsx-scope": "off",
+    "react/jsx-curly-brace-presence": "off",
+    "react/jsx-wrap-multilines": "off",
     "max-len": "off",
     "new-cap": ["error", {"capIsNewExceptions": ["Immutable"]}],
     "no-confusing-arrow": ["error", {"allowParens": true}],

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     }
   ],
   "productName": "Caption",
-  "version": "2.0.0-alpha",
+  "version": "2.0.0",
   "main": "main/index.js",
   "license": "MIT",
   "repository": "gielcobben/Caption",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     }
   ],
   "productName": "Caption",
-  "version": "2.0.0",
+  "version": "2.0.0-alpha",
   "main": "main/index.js",
   "license": "MIT",
   "repository": "gielcobben/Caption",

--- a/renderer/components/Meta.js
+++ b/renderer/components/Meta.js
@@ -1,14 +1,13 @@
 import { remote } from "electron";
 
-import Title from "./Title";
 import Logo from "./Logo";
 
-const Meta = () =>
+const Meta = ({ appVersion }) =>
   <section>
     <Logo />
     <div>
       <h1>Caption</h1>
-      Version: <span>2.0.0</span>
+      Version: <span>{appVersion}</span>
     </div>
 
     <style jsx>{`
@@ -38,7 +37,8 @@ const Meta = () =>
         font-weight: 500;
         color: #000;
       }
-    `}</style>
+    `}
+    </style>
   </section>;
 
 export default Meta;

--- a/renderer/pages/about.js
+++ b/renderer/pages/about.js
@@ -1,16 +1,52 @@
+import electron from "electron";
+import { Component } from "react";
+import isDev from "electron-is-dev";
+
 import Layout from "../components/Layout";
 import TitleBar from "../components/TitleBar";
 import Meta from "../components/Meta";
 import Credits from "../components/Credits";
 import FooterAbout from "../components/FooterAbout";
 
-const About = () => (
-  <Layout>
-    <TitleBar title="About" />
-    <Meta />
-    <Credits />
-    <FooterAbout />
-  </Layout>
-);
+class About extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      version: '0.0.0'
+    };
+
+    this.remote = electron.remote || false;
+  }
+
+  componentWillMount() {
+    if (!this.remote) {
+      return;
+    }
+
+    let version;
+
+    if (isDev) {
+      version = this.remote.process.env.npm_package_version;
+    } else {
+      version = this.remote.app.getVersion();
+    }
+
+    this.setState({
+      version
+    });
+  }
+
+  render() {
+    return (
+      <Layout>
+        <TitleBar title="About" />
+        <Meta appVersion={this.state.version} />
+        <Credits />
+        <FooterAbout />
+      </Layout>
+    );
+  }
+}
 
 export default About;


### PR DESCRIPTION
- Fix some annoying ESLint warnings by updating config.
- Retrieve application version from package.json (in development) or use real app version (in production).