### PR TITLE
Update Electron updater

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "electron-lets-move": "0.0.5",
     "electron-next": "3.1.1",
     "electron-store": "^1.3.0",
-    "electron-updater": "^2.15.0",
+    "electron-updater": "^2.16.1",
     "electron-window-state": "^4.1.1",
     "lodash": "^4.17.4",
     "next-redux-wrapper": "^1.3.4",


### PR DESCRIPTION
I got an error while running `npm run dist`:

```
Error: At least electron-updater 2.16.1 is required by current electron-builder version
```