### PR TITLE
Pass along search-item to Caption.download instead of hardcoded payload

### DIFF
--- a/main/download.js
+++ b/main/download.js
@@ -9,22 +9,20 @@ const multiDownload = files => {
   const { mainWindow } = global.windows;
 
   try {
-    const downloadFiles = files.map(({ file, subtitle }) =>
+    const downloadFiles = files.map(item =>
       new Promise(resolve => {
-        const downloadLocation = path.dirname(file.path);
-        const originalFileName = file.name;
+        const downloadLocation = path.dirname(item.file.path);
+        const originalFileName = item.file.name;
         const subtitleFilename = originalFileName.replace(/\.[^/.]+$/, "");
 
         return Caption.download(
-          {
-            downloadUrl: subtitle.url,
-          },
-          "opensubtitles",
+          item,
+          item.source,
           `${downloadLocation}/${subtitleFilename}.srt`,
         ).then(() => {
           resultSet.push(`${downloadLocation}/${subtitleFilename}.srt`);
           mainWindow.webContents.send("updateFileSearchStatus", {
-            filePath: file.path,
+            filePath: item.file.path,
             status: "done",
           });
           resolve();


### PR DESCRIPTION
Hi guys,

In addition to this PR https://github.com/gielcobben/caption-core/pull/6, my changes in the caption project.

It basically makes sure Caption.download is called directly with the given search-result.
The source in the `caption-core` should be able to figure out how to download the subtitle by himself.

It enables more download-sources to be added.

Please let me know what you think :-)

Regards,

Jeffrey Zutt